### PR TITLE
ENH: add adjustable dosage

### DIFF
--- a/bin/simulation/simulate.py
+++ b/bin/simulation/simulate.py
@@ -21,6 +21,10 @@ def main():
                         required=False,
                         type=str,
                         help="Path to m2m folder, required if using --gifti")
+    parser.add_argument("--dosage",
+                        required=False,
+                        type=float,
+                        help="TMS dosage to use (dI/dt)")
 
     args = parser.parse_args()
 
@@ -40,6 +44,7 @@ def main():
 
     pos = tmslist.add_position()
     pos.matsimnibs = np.load(args.matsimnibs)
+    pos.didt = float(args.dosage) if args.dosage else None
 
     s.run()
 

--- a/config/base.nf.config
+++ b/config/base.nf.config
@@ -21,7 +21,7 @@ singularity {
 retry_val=3
 license="/freesurfer/6.0.0/build/"
 params.atlas_dir="${projectDir.getParent()}/standard_mesh_atlases/resample_fsaverage"
-params.default_dose=10e8
+params.default_dose=10e6
 
 profiles {
 

--- a/config/base.nf.config
+++ b/config/base.nf.config
@@ -21,6 +21,7 @@ singularity {
 retry_val=3
 license="/freesurfer/6.0.0/build/"
 params.atlas_dir="${projectDir.getParent()}/standard_mesh_atlases/resample_fsaverage"
+params.default_dose=10e8
 
 profiles {
 

--- a/modules/simulate.nf
+++ b/modules/simulate.nf
@@ -33,7 +33,9 @@ process simulate{
     label 'bin'
 
     input:
-    tuple val(sub), path(mesh), path(matsimnibs), path(coil), path(m2m_path), path(fs_path)
+    tuple val(sub), path(mesh), path(matsimnibs),\
+    path(coil), path(m2m_path), path(fs_path),\
+    val(dosage)
 
     output:
     tuple val(sub), path("${sub}_TMS*.msh"), emit: simMsh
@@ -49,7 +51,8 @@ process simulate{
         !{mesh} \
         !{matsimnibs} \
         !{coil} \
-        --gifti --m2m-path !{m2m_path}
+        --gifti --m2m-path !{m2m_path} \
+        --dose !{dosage}
     '''
 }
 
@@ -63,6 +66,7 @@ workflow runSimulate{
         m2m_path
         twist
         coil
+        dosages
 
     main:
 
@@ -76,6 +80,7 @@ workflow runSimulate{
                 .combine(coil)
                 .join(m2m_path)
                 .join(fs_path)
+                .join(dosages)
         )
 
     emit:

--- a/pipeline/simulate_mni.nf
+++ b/pipeline/simulate_mni.nf
@@ -48,9 +48,9 @@ parser.addOptional("--warps_file",
 parser.addOptional("--mni_standard",
     "Path to MNI standard registration target, required if --warp_files not provided",
     "MNI_STANDARD")
-parser.addOptional("--mt_file",
-    "Path to CSV file containing (subject, MT MSO) entries",
-    "MT_FILE")
+parser.addOptional("--didt_file",
+    "Path to CSV file containing (subject, DIDT) entries",
+    "DIDT_FILE")
 
 parser.addOptional("--create_cifti", "Generate CIFTI outputs")
 
@@ -236,8 +236,8 @@ workflow getOrCreateWarps{
 
 workflow getOrCreateDosage{
     main:
-        if (params.mt_file){
-            dosages = Channel.fromPath(params.mt_file)
+        if (params.didt_file){
+            dosages = Channel.fromPath(params.didt_file)
                         .splitCsv(header: ['subject', 'mt'])
             subjects.join(dosages, failOnMismatch: true)
         } else {

--- a/pipeline/simulate_mni.nf
+++ b/pipeline/simulate_mni.nf
@@ -238,7 +238,7 @@ workflow getOrCreateDosage{
     main:
         if (params.didt_file){
             dosages = Channel.fromPath(params.didt_file)
-                        .splitCsv(header: ['subject', 'mt'])
+                        .splitCsv(header: ['subject', 'didt'])
             subjects.join(dosages, failOnMismatch: true)
         } else {
             dosages = subjects.combine([params.default_dose])


### PR DESCRIPTION
Allow for MT adjustment on a participant by participant level:

Extends the `simulate_mni.nf` pipeline with `--didt_file DIDT_FILE` where `DIDT_FILE` is a csv of form:
```
subject, didt
<SUB_ID>,<DIDT>
```

didt will need to be computed based on the specific coil, simulator, and participant %MT. Hence why, we cannot compute based just off %MT alone.